### PR TITLE
dev: 학습 / 평가 / 테스트 데이터셋 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__
 .empty
-*/data/*
+data/
 README.pdf
 
 # sub_task3

--- a/README.md
+++ b/README.md
@@ -18,12 +18,38 @@
   - CUDA 11.6
 
 1. `git clone` 명령어로 본 repository를 복사
-2. Anaconda 혹은 Miniconda를 설치하고, `conda create -n fashion_how python==3.10.12` 명령어로 가상환경을 생성. (권장, 필수 X)
-3. `pip install -r requirements.txt` 명령어를 이용하여 필요한 라이브러리 설치
-4. `cd sub_task3_custom` 명령어를 통해 이동
-5. 터미널 상에서 `sh run_example.sh` 명령어를 실행하여 실험을 진행. **Data 관련 인자들은 경로 주의**
-6. 모든 데이터에 대해 학습 및 평가가 완료된 후 재현이 올바르게 되었는지 확인하고 싶다면, `nohup_logs/21_18_dec_mem_size.out` 파일의 최종 score와 비교해보면 됨.
-**Validation으로 사용한 data는 .tst가 아닌 .dev인 점을 주의**
+1. Anaconda 혹은 Miniconda를 설치하고, `conda create -n fashion_how python==3.10.12` 명령어로 가상환경을 생성. (권장, 필수 X)
+1. `pip install -r requirements.txt` 명령어를 이용하여 필요한 라이브러리 설치
+1. [FASHION-HOW LEADERBOARD 3](https://fashion-how.org/ETRI23/fascode_board/season4/leaderboard3/leader3outline.html) 페이지로 이동한 뒤, [신규)학습용 데이터셋 다운로드(링크)](https://drive.google.com/file/d/1E0dVb4W_QuWpuUQyGPLLo7Md41gUerPD/view?usp=sharing)와 [Validation Set 다운로드 (링크)](https://drive.google.com/file/d/1ZNPzt3t9D8r-ZkE8yB3o9He2kqqFp2l_/view)를 눌러 데이터를 다운로드
+1. 다운받은 데이터셋을 아래 형식과 동일하게 구성
+    ```
+    23-Fashion-How
+      >> .git
+      >> .github
+      >> after_competition
+      >> data
+        >> dialogue
+        >  >> eval
+        >  >  >> cl_eval_task*.dev (dev로 끝나는 파일 모두를 저장. 총 12개)
+        >  >
+        >  >> tr
+        >  >  >> task*.ddata.txt (txt로 끝나는 파일 모두를 저장. 총 12개)
+        >  >
+        >  >> tt
+        >  >  >> cl_eval_task*.tst (tst로 끝나는 파일 모두를 저장. 총 12개)
+        >  
+        >> img_feats
+        >> img_jpg
+        >> sstm_v0p5_deploy
+        >
+        >> mdata.txt.2023.0823
+        >> mdata.wst.txt.2023.0823
+      >> ...
+    ```
+1. `cd sub_task3_custom` 명령어를 통해 이동
+1. 터미널 상에서 `bash run_example.sh` 명령어를 실행하여 실험을 진행.
+1. 모든 데이터에 대해 학습 및 평가가 완료된 후 재현이 올바르게 되었는지 확인하고 싶다면, `nohup_logs/21_18_dec_mem_size.out` 파일의 최종 score와 비교해보면 됨. 
+**Validation으로 사용한 data는 .tst가 아닌 .dev인 점을 주의** (업데이트 예정)
 <br>
 
 ## 팀 둥굴레 멤버

--- a/sub_task3_custom/run_example.sh
+++ b/sub_task3_custom/run_example.sh
@@ -1,60 +1,67 @@
 ### train task#1 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task1.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-### test task#1 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task1.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+### eval task#1 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
 ### train task#2 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task2.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
-### test task#2 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task2.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
+### eval task#2 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
 ### train task#3 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task3.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
-### test task#3 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task3.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
+### eval task#3 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
 ### train task#4 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task4.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
-### test task#4 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task4.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
+### eval task#4 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
 ### train task#5 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task5.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
-### test task#5 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task5.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
+### eval task#5 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
 ### train task#6 ###
-sh run_train.sh --in_file_trn_dialog /home/suyeongp7/data/task6.ddata.wst.txt --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
-### test task#6 ###
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
-sh run_test.sh --in_file_tst_dialog /home/suyeongp7/data/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
+sh run_train.sh --in_file_trn_dialog ../data/dialogue/tr/task6.ddata.wst.txt --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model --model_file gAIa-final.pt
+### eval task#6 ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task1.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task2.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task3.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task4.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task5.wst.dev --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/eval/cl_eval_task6.wst.dev --model_path ./gAIa_CL_model
 
+### test all ###
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task1.wst.tst --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task2.wst.tst --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task3.wst.tst --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task4.wst.tst --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task5.wst.tst --model_path ./gAIa_CL_model
+sh run_test.sh --in_file_tst_dialog ../data/dialogue/tt/cl_eval_task6.wst.tst --model_path ./gAIa_CL_model

--- a/sub_task3_custom/run_test.sh
+++ b/sub_task3_custom/run_test.sh
@@ -5,8 +5,8 @@
 
 CUDA_VISIBLE_DEVICES="0" python3 ./main.py --seed 2023 \
                                    --mode test \
-                                   --in_file_fashion /home/suyeongp7/data/mdata.wst.txt.2023.08.23 \
-                                   --subWordEmb_path /home/suyeongp7/data/sstm_v0p5_deploy/sstm_v4p49_np_n36134_d128.dat \
+                                   --in_file_fashion ../data/mdata.wst.txt.2023.08.23 \
+                                   --subWordEmb_path ../data/sstm_v0p5_deploy/sstm_v4p49_np_n36134_d128.dat \
                                    --model_file gAIa-final.pt \
                                    --mem_size 8 \
                                    --key_size 300 \

--- a/sub_task3_custom/run_train.sh
+++ b/sub_task3_custom/run_train.sh
@@ -9,8 +9,8 @@
 
 CUDA_VISIBLE_DEVICES="0" python3 ./main.py --seed 2023 \
                                      --mode train \
-                                     --in_file_fashion /home/suyeongp7/data/mdata.wst.txt.2023.08.23 \
-                                     --subWordEmb_path /home/suyeongp7/data/sstm_v0p5_deploy/sstm_v4p49_np_n36134_d128.dat \
+                                     --in_file_fashion ../data/mdata.wst.txt.2023.08.23 \
+                                     --subWordEmb_path ../data/sstm_v0p5_deploy/sstm_v4p49_np_n36134_d128.dat \
                                      --mem_size 8 \
                                      --key_size 300 \
                                      --hops 3 \


### PR DESCRIPTION
## Reference
- #3 기반 작업입니다.
- 테스트 데이터셋 구축을 위해 원본 데이터를 확인해본 결과, 대회 당시 두 개의 validation data가 제공되었었는데, 각각의 data가 서로 다른 내용이었습니다. 따라서 기존에 사용하던 validation data는 그대로 평가 데이터로 사용하고, 사용하지 않았던 validation data를 테스트 데이터로 사용하여 모델의 성능을 비교할 생각입니다.
- 그에 따라 데이터 경로를 수정했습니다.

## Done
- `.gitignore`: 데이터 경로를 수정했습니다.
- `README.md`: repository 사용법을 업데이트했습니다. 리팩토링 과정이 진행됨에 따라 계속해서 업데이트 할 예정입니다.
- `run_example.sh`: 학습, 평가 데이터 경로 수정 및 테스트 데이터로 inference하는 명령어를 추가했습니다.
- `run_train.sh`: 데이터 경로를 수정했습니다.
- `run_test.sh`: 데이터 경로를 수정했습니다.

## See Also
-